### PR TITLE
fix "treasure" typo on quest page

### DIFF
--- a/pages/town/quest.js
+++ b/pages/town/quest.js
@@ -28,7 +28,7 @@ function	DialogChoices({router, adventurersCount}) {
 			options={[
 				{label: 'WELCOME', onClick: () => router.push('/town/quest')},
 				{label: 'THE RAT IN THE CELLAR', onClick: () => router.push('/town/quest?tab=the-cellar')},
-				{label: 'THE TRESURE IN THE FOREST', onClick: () => router.push('/town/quest?tab=the-forest')},
+				{label: 'THE TREASURE IN THE FOREST', onClick: () => router.push('/town/quest?tab=the-forest')},
 			]} />
 	);
 }


### PR DESCRIPTION
Just fixing simple typo on quest page.